### PR TITLE
Revert "manifest: switch blobs to TheMuppets"

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,8 +21,8 @@
            review="codeaurora.org"/>
            
   <remote name="blobs"
-           fetch="https://github.com/TheMuppets"
-           revision="cm-14.1"/>
+           fetch="https://github.com/ThankYouMario"
+           revision="nougat-mr2"/>
        
   <remote  name="github"
            fetch="https://github.com"/>


### PR DESCRIPTION
The 'blobs' remote is only used to sync sdclang-3.8, TheMuppets do not have an equivalent repo therefore this breaks repo sync.

This reverts commit ce678b5a87356c2d1128de914c62ec2d5366b91e.